### PR TITLE
Set zfs-auto-snapshot to use UTC time for snapshots

### DIFF
--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -504,7 +504,7 @@ SNAPPROP="-o com.sun:auto-snapshot-desc='$opt_event'"
 
 # ISO style date; fifteen characters: YYYY-MM-DD-HHMM
 # On Solaris %H%M expands to 12h34.
-DATE=$(date +%F-%H%M)
+DATE=$(date --utc +%F-%H%M)
 
 # The snapshot name after the @ symbol.
 SNAPNAME="$opt_prefix${opt_label:+$opt_sep$opt_label-$DATE}"


### PR DESCRIPTION
I ran into a bug when deploying this + Samba4 for Previous Versions to a Windows 7 client - all of the snapshots were appearing as 'Tomorrow'. It seems that Windows 7, at least, expects the date given to be in UTC. As I'm in UTC+8, this made all of the dates 8h ahead!

Just added the --utc flag to the date code there, and Windows 7 now correctly gives the date. This shouldn't affect anything else, since cron takes care of scheduling. UTC is also better idea to be storing the snapshot date in, as well.
