### PR TITLE
Fix SNAPNAME to contain the DATE if label is empty

### DIFF
--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -507,7 +507,7 @@ SNAPPROP="-o com.sun:auto-snapshot-desc='$opt_event'"
 DATE=$(date --utc +%F-%H%M)
 
 # The snapshot name after the @ symbol.
-SNAPNAME="$opt_prefix${opt_label:+$opt_sep$opt_label-$DATE}"
+SNAPNAME="$opt_prefix${opt_label:+$opt_sep$opt_label}-$DATE"
 
 # The expression for matching old snapshots.  -YYYY-MM-DD-HHMM
 SNAPGLOB="$opt_prefix${opt_label:+?$opt_label}????????????????"


### PR DESCRIPTION
When I didn't specify a `--label` on the commandline, the SNAPNAME was missing the $DATE component
