### PR TITLE
Add option --utc to use UTC dates in snapshot names instead of the local time zone.

### DIFF
--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -158,6 +158,10 @@ do_snapshots () # properties, flags, snapname, oldglob, [targets...]
 
 	for ii in $TARGETS
 	do
+        if echo $SNAPSHOTS_OLD | grep -q "$ii@$NAME"
+        then
+            do_run "zfs destroy $FLAGS '$ii@$NAME'"
+        fi
 		if do_run "zfs snapshot $PROPS $FLAGS '$ii@$NAME'" 
 		then
 			SNAPSHOT_COUNT=$(( $SNAPSHOT_COUNT + 1 ))


### PR DESCRIPTION
For zfsonlinux/zfs-auto-snapshot/issues/19

Enabling this as a command line switch is the best option, IMHO.  Default should obey time zone set on machine.
