### PR TITLE
Add pre and post snapshot hooks

### DIFF
--- a/src/zfs-auto-snapshot.8
+++ b/src/zfs-auto-snapshot.8
@@ -64,6 +64,15 @@ Snapshot named filesystem and all descendants.
 \fB\-v\fR, \fB\-\-verbose\fR
 Print info messages.
 .TP
+\fB\-\-pre-snapshot\fR
+Command to run before snapshotting. It is passed the
+filesystem and snapshot name. If it returns non-zero,
+snapshotting this filesystem is aborted.
+.TP
+\fB\-\-post-snapshot\fR
+Command to run after snapshotting. It is passed the
+filesystem and snapshot name.
+.TP
 name
 Filesystem and volume names, or '//' for all ZFS datasets.
 .SH SEE ALSO

--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -159,7 +159,7 @@ do_snapshots () # properties, flags, snapname, oldglob, [targets...]
 	for ii in $TARGETS
 	do
 		do_run "$opt_pre_snapshot $ii $NAME"
-		if do_run "zfs snapshot $PROPS $FLAGS '$ii@$NAME'" 
+		if [ $? -eq 0 ] && do_run "zfs snapshot $PROPS $FLAGS '$ii@$NAME'"
 		then
 			do_run "$opt_post_snapshot $ii $NAME"
 			SNAPSHOT_COUNT=$(( $SNAPSHOT_COUNT + 1 ))

--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -39,6 +39,8 @@ opt_setauto=''
 opt_syslog=''
 opt_skip_scrub=''
 opt_verbose=''
+opt_pre_snapshot=''
+opt_post_snapshot=''
 
 # Global summary statistics.
 DESTRUCTION_COUNT='0'
@@ -156,8 +158,10 @@ do_snapshots () # properties, flags, snapname, oldglob, [targets...]
 
 	for ii in $TARGETS
 	do
+		do_run "$opt_pre_snapshot $ii $NAME"
 		if do_run "zfs snapshot $PROPS $FLAGS '$ii@$NAME'" 
 		then
+			do_run "$opt_post_snapshot $ii $NAME"
 			SNAPSHOT_COUNT=$(( $SNAPSHOT_COUNT + 1 ))
 		else
 			WARNING_COUNT=$(( $WARNING_COUNT + 1 ))
@@ -198,6 +202,7 @@ GETOPT=$(getopt \
   --longoptions=default-exclude,dry-run,fast,skip-scrub,recursive \
   --longoptions=event:,keep:,label:,prefix:,sep: \
   --longoptions=debug,help,quiet,syslog,verbose \
+  --longoptions=pre-snapshot:,post-snapshot: \
   --options=dnshe:l:k:p:rs:qgv \
   -- "$@" ) \
   || exit 128
@@ -307,6 +312,14 @@ do
 			opt_quiet=''
 			opt_verbose='1'
 			shift 1
+			;;
+		(--pre-snapshot)
+			opt_pre_snapshot="$2"
+			shift 2
+			;;
+		(--post-snapshot)
+			opt_post_snapshot="$2"
+			shift 2
 			;;
 		(--)
 			shift 1


### PR DESCRIPTION
This adds `--pre-` and `--post-snapshot` switches, which execute, respectively, before and after snapshot is made.

If the pre hook fails, snapshotting this filesystem is aborted.

If we decide to merge this, should we remove unimplemented send switches from manual? It seems like those hooks would cover that.
