### PR TITLE
zfs destroy will use -d for deferred destruction

### DIFF
--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -191,7 +191,7 @@ do_snapshots () # properties, flags, snapname, oldglob, [targets...]
 				KEEP=$(( $KEEP - 1 ))
 				if [ "$KEEP" -le '0' ]
 				then
-					if do_run "zfs destroy $FLAGS '$jj'" 
+					if do_run "zfs destroy -d $FLAGS '$jj'" 
 					then
 						DESTRUCTION_COUNT=$(( $DESTRUCTION_COUNT + 1 ))
 					else


### PR DESCRIPTION
I am working on a complimentary script that does log-shipping style replication to a backup volume for highly efficient incremental backups. This relies on "zfs send -R" and that the sets of snapshots existing on the source and backup destination overlap by at least one snapshot. I plan to use snapshot clones to place a "checkpoint" reservation on a snapshot that will be required for future backups.

In order to keep zfs-auto-snapshot from destroying a snapshot necessary for a future incremental backup replication stream, I will create an unmounted clone of that snapshot, and destroy any prior clones when the backup completes. 

Any snapshots destroyed by the zfs-auto-snapshot "zfs destroy -d" will be destroyed as the dependent clones are destroyed. Without the -d option, zfs-auto-snapshot would fail to destroy the old snapshot with a checkpoint clone, and it would persist until later snapshot jobs destroy it in subsequent runs. Since monthlies and weeklies are relatively infrequent, deferred destruction will reap the snapshots opportunistically as soon as the "checkpoint" clones are gone, potentially days or weeks sooner than the next zfs-auto-snapshot.sh run. Intermediate snapshots between the "checkpoint" reserved snapshots and the recent snapshots preserved by the zfs-auto-snapshot.sh will still be immediately destroyed.
