### PR TITLE
Fix frequent cronjob

### DIFF
--- a/etc/zfs-auto-snapshot.cron.frequent
+++ b/etc/zfs-auto-snapshot.cron.frequent
@@ -1,3 +1,3 @@
-PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+PATH="/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
 
 */15 * * * * root zfs-auto-snapshot -q -g --label=frequent --keep=4  //

--- a/etc/zfs-auto-snapshot.cron.frequent
+++ b/etc/zfs-auto-snapshot.cron.frequent
@@ -1,3 +1,3 @@
 PATH="/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
 
-*/15 * * * * root zfs-auto-snapshot -q -g --label=frequent --keep=4  //
+*/15 * * * * root zfs-auto-snapshot --quiet --syslog --label=frequent --keep=4  //


### PR DESCRIPTION
Since a1b89b6fefc8563bffe0a74582633530fae4837c zfs-auto-snapshot is installed into /usr/local/sbin, but that directory is not included in the PATH variable for the frequent cronjob.

Also make the frequent cronjob use the long command line options (as the others do).
