### PR TITLE
Fix SNAPNAME and SNAPGLOB.

### DIFF
--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -533,10 +533,10 @@ SNAPPROP="-o com.sun:auto-snapshot-desc='$opt_event'"
 DATE=$(date --utc +%F-%H%M)
 
 # The snapshot name after the @ symbol.
-SNAPNAME="$opt_prefix${opt_label:+$opt_sep$opt_label}-$DATE"
+SNAPNAME="${opt_prefix:+$opt_prefix$opt_sep}${opt_label:+$opt_label}-$DATE"
 
 # The expression for matching old snapshots.  -YYYY-MM-DD-HHMM
-SNAPGLOB="$opt_prefix${opt_label:+?$opt_label}????????????????"
+SNAPGLOB="${opt_prefix:+$opt_prefix$opt_sep}${opt_label:+$opt_label}-???????????????"
 
 if [ -n "$opt_do_snapshots" ]
 then


### PR DESCRIPTION
Currently the following command line:

```
    zfs-auto-snapshot.sh.orig --keep 7 --label daily --prefix '' --sep '-' \
      --event "daily-$(date --utc +"%Y%m%d.%H%M")" --recursive --verbose //
```

  will give the following result:

```
    zfs snapshot -o com.sun:auto-snapshot-desc='daily-20150403.0013' \
      -r 'share/.Bacula@-daily-2015-04-03-0013'
```

Notice the prefixing dash in the snap name. If instead <code>prefix=daily</code>, this would be the result:

```
    zfs snapshot -o com.sun:auto-snapshot-desc='daily-20150403.0015' \
      -r 'share/.Bacula@daily-daily-2015-04-03-0016'
```

If <code>prefix=daily</code> and <code>label=NULL</code>:

```
    zfs snapshot -o com.sun:auto-snapshot-desc='daily-20150403.0017' \
      -r 'share@daily'
```

This because <code>SNAPNAME</code> is constructed wrongly. Instead, only separate the <code>prefix</code> from the <code>label</code> with <code>sep</code> if <code>prefix</code> is actually set instead of using <code>prefix</code> (wether it's set or not), add <code>sep</code> and then <code>label</code>...

Construct <code>SNAPGLOB</code> so that it matches this.
