### PR TITLE
Fix command path

### DIFF
--- a/etc/zfs-auto-snapshot.cron.daily
+++ b/etc/zfs-auto-snapshot.cron.daily
@@ -1,3 +1,2 @@
 #!/bin/sh
-PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin"
-exec zfs-auto-snapshot --quiet --syslog --label=daily --keep=31 //
+exec /usr/local/sbin/zfs-auto-snapshot --quiet --syslog --label=daily --keep=31 //

--- a/etc/zfs-auto-snapshot.cron.daily
+++ b/etc/zfs-auto-snapshot.cron.daily
@@ -1,2 +1,3 @@
 #!/bin/sh
+PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin"
 exec zfs-auto-snapshot --quiet --syslog --label=daily --keep=31 //

--- a/etc/zfs-auto-snapshot.cron.frequent
+++ b/etc/zfs-auto-snapshot.cron.frequent
@@ -1,3 +1,3 @@
-PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin"
+PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 
-*/15 * * * * root zfs-auto-snapshot -q -g --label=frequent --keep=4  //
+*/15 * * * * root /usr/local/sbin/zfs-auto-snapshot -q -g --label=frequent --keep=4  //

--- a/etc/zfs-auto-snapshot.cron.frequent
+++ b/etc/zfs-auto-snapshot.cron.frequent
@@ -1,3 +1,3 @@
-PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin"
 
 */15 * * * * root zfs-auto-snapshot -q -g --label=frequent --keep=4  //

--- a/etc/zfs-auto-snapshot.cron.hourly
+++ b/etc/zfs-auto-snapshot.cron.hourly
@@ -1,3 +1,2 @@
 #!/bin/sh
-PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin"
-exec zfs-auto-snapshot --quiet --syslog --label=hourly --keep=24 //
+exec /usr/local/sbin/zfs-auto-snapshot --quiet --syslog --label=hourly --keep=24 //

--- a/etc/zfs-auto-snapshot.cron.hourly
+++ b/etc/zfs-auto-snapshot.cron.hourly
@@ -1,2 +1,3 @@
 #!/bin/sh
+PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin"
 exec zfs-auto-snapshot --quiet --syslog --label=hourly --keep=24 //

--- a/etc/zfs-auto-snapshot.cron.monthly
+++ b/etc/zfs-auto-snapshot.cron.monthly
@@ -1,2 +1,3 @@
 #!/bin/sh
+PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin"
 exec zfs-auto-snapshot --quiet --syslog --label=monthly --keep=12 //

--- a/etc/zfs-auto-snapshot.cron.monthly
+++ b/etc/zfs-auto-snapshot.cron.monthly
@@ -1,3 +1,2 @@
 #!/bin/sh
-PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin"
-exec zfs-auto-snapshot --quiet --syslog --label=monthly --keep=12 //
+exec /usr/local/sbin/zfs-auto-snapshot --quiet --syslog --label=monthly --keep=12 //

--- a/etc/zfs-auto-snapshot.cron.weekly
+++ b/etc/zfs-auto-snapshot.cron.weekly
@@ -1,3 +1,2 @@
 #!/bin/sh
-PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin"
-exec zfs-auto-snapshot --quiet --syslog --label=weekly --keep=8 //
+exec /usr/local/sbin/zfs-auto-snapshot --quiet --syslog --label=weekly --keep=8 //

--- a/etc/zfs-auto-snapshot.cron.weekly
+++ b/etc/zfs-auto-snapshot.cron.weekly
@@ -1,2 +1,3 @@
 #!/bin/sh
+PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin"
 exec zfs-auto-snapshot --quiet --syslog --label=weekly --keep=8 //


### PR DESCRIPTION
Does not work on CentOS7.
Scripts installed in `/usr/local/sbin/`. But not in the path.
