### PR TITLE
Fix broken cron scripts

### DIFF
--- a/etc/zfs-auto-snapshot.cron.daily
+++ b/etc/zfs-auto-snapshot.cron.daily
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 # Only call zfs-auto-snapshot if it's available
-exec which zfs-auto-snapshot > /dev/null && \
+which zfs-auto-snapshot > /dev/null && \
      zfs-auto-snapshot --quiet --syslog --label=daily --keep=31 //

--- a/etc/zfs-auto-snapshot.cron.daily
+++ b/etc/zfs-auto-snapshot.cron.daily
@@ -2,4 +2,4 @@
 
 # Only call zfs-auto-snapshot if it's available
 which zfs-auto-snapshot > /dev/null && \
-     zfs-auto-snapshot --quiet --syslog --label=daily --keep=31 //
+     exec zfs-auto-snapshot --quiet --syslog --label=daily --keep=31 //

--- a/etc/zfs-auto-snapshot.cron.hourly
+++ b/etc/zfs-auto-snapshot.cron.hourly
@@ -2,4 +2,4 @@
 
 # Only call zfs-auto-snapshot if it's available
 which zfs-auto-snapshot > /dev/null && \
-     zfs-auto-snapshot --quiet --syslog --label=hourly --keep=24 //
+     exec zfs-auto-snapshot --quiet --syslog --label=hourly --keep=24 //

--- a/etc/zfs-auto-snapshot.cron.hourly
+++ b/etc/zfs-auto-snapshot.cron.hourly
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 # Only call zfs-auto-snapshot if it's available
-exec which zfs-auto-snapshot > /dev/null && \
+which zfs-auto-snapshot > /dev/null && \
      zfs-auto-snapshot --quiet --syslog --label=hourly --keep=24 //

--- a/etc/zfs-auto-snapshot.cron.monthly
+++ b/etc/zfs-auto-snapshot.cron.monthly
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 # Only call zfs-auto-snapshot if it's available
-exec which zfs-auto-snapshot > /dev/null && \
+which zfs-auto-snapshot > /dev/null && \
      zfs-auto-snapshot --quiet --syslog --label=monthly --keep=12 //

--- a/etc/zfs-auto-snapshot.cron.monthly
+++ b/etc/zfs-auto-snapshot.cron.monthly
@@ -2,4 +2,4 @@
 
 # Only call zfs-auto-snapshot if it's available
 which zfs-auto-snapshot > /dev/null && \
-     zfs-auto-snapshot --quiet --syslog --label=monthly --keep=12 //
+     exec zfs-auto-snapshot --quiet --syslog --label=monthly --keep=12 //

--- a/etc/zfs-auto-snapshot.cron.weekly
+++ b/etc/zfs-auto-snapshot.cron.weekly
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 # Only call zfs-auto-snapshot if it's available
-exec which zfs-auto-snapshot > /dev/null && \
+which zfs-auto-snapshot > /dev/null && \
      zfs-auto-snapshot --quiet --syslog --label=weekly --keep=8 //

--- a/etc/zfs-auto-snapshot.cron.weekly
+++ b/etc/zfs-auto-snapshot.cron.weekly
@@ -2,4 +2,4 @@
 
 # Only call zfs-auto-snapshot if it's available
 which zfs-auto-snapshot > /dev/null && \
-     zfs-auto-snapshot --quiet --syslog --label=weekly --keep=8 //
+     exec zfs-auto-snapshot --quiet --syslog --label=weekly --keep=8 //


### PR DESCRIPTION
I found that none of the daily, hourly, weekly or monthly snapshots were
being taken. When I looked into it I found that the scripts didn't
execute properly, because of the newly introduced check (9c6f065).

I'm not versed enough with POSIX to understand if there was some clever
intention with using exec than just calling which by it self, but it
works without exec so I removed it.

~~Forgot to test on multiple machines before I pushed. Realizing this is an issue on my Ubuntu 16.10 box but not on Arch. Huh.~~
EDIT: Don't know what I was talking about. It does not work on Arch either.