### PR TITLE
make --quiet really quiet

### DIFF
--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -110,7 +110,7 @@ print_log () # level, message, ...
 			;;
 		(inf*)
 			# test -n "$opt_syslog" && logger -t "$opt_prefix" -p daemon.info $*
-			test -n "$opt_verbose" && echo $*
+			test -z ${opt_quiet+x} && test -n "$opt_verbose" && echo $*
 			;;
 		(deb*)
 			# test -n "$opt_syslog" && logger -t "$opt_prefix" -p daemon.debug $*


### PR DESCRIPTION
--quiet still prints the name of the datasets when print_log is called at lines 548/551
not sure if this is the right way to fix it. works for me in my cron invocation:
--quiet --syslog --label=hourly --keep=24 --fast --default-exclude --min-size=1 //
this way I am no longer spammed by cron output while at the same time not having to change each cron entry