### PR TITLE
Exclude datasets with readonly=on if the --skip-readonly flag is set

### DIFF
--- a/src/zfs-auto-snapshot.8
+++ b/src/zfs-auto-snapshot.8
@@ -31,6 +31,9 @@ Print actions without actually doing anything.
 \fB\-s\fR, \fB\-\-skip\-scrub\fR
 Do not snapshot filesystems in scrubbing pools.
 .TP
+\fB\-w\fR, \fB\-\-skip\-readonly\fR
+Do not snapshot filesystems which are readonly.
+.TP
 \fB\-h\fR, \fB\-\-help\fR
 Print the usage message.
 .TP


### PR DESCRIPTION
In some use cases it would be convenient if zfs-auto-snapshot ignores datasets which are readonly=on regardless of the value in com.sun:auto-snapshot.

I am considering a setup using both zfs-auto-snapshot and zrep. zrep facilitates two way zfs replication with failover. The status of of the paired fs is kept in zfs properties. The 'master' have zrep:master=yes and readonly=off whereas the 'slave' have zrep:master=no and readonly=on.

For the replication to work snapshots cannot be added to the 'slave'. This could potentially be avoided if
zfs-auto-snapshot, perhaps by providing an optional flag '--skip-readonly', did not create snapshots for datasets that are readonly=on regardless of their value in com.sun:auto-snapshot.

With such modification of zfs-auto-snapshot's behavior, it would be possible to run 'zrep sync all' as a cron job together with zfs-auto-snapshot on both servers and auto-snapshot and replication-failover would "just work", where failover or takeover can be issued on each dataset individually.

Yes, in general, snapshotting datasets which are readonly=on costs very little, but for the above mentioned reason, and potentially others reasons too, usability can in some instances improve if it can be avoided.