### PR TITLE
Add /usr/local/sbin to PATH for cron.daily/hourly/monthly/weekly

### DIFF
--- a/etc/zfs-auto-snapshot.cron.daily
+++ b/etc/zfs-auto-snapshot.cron.daily
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+PATH="$PATH:/usr/local/sbin"
+
 # Only call zfs-auto-snapshot if it's available
 which zfs-auto-snapshot > /dev/null || exit 0
 

--- a/etc/zfs-auto-snapshot.cron.hourly
+++ b/etc/zfs-auto-snapshot.cron.hourly
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+PATH="$PATH:/usr/local/sbin"
+
 # Only call zfs-auto-snapshot if it's available
 which zfs-auto-snapshot > /dev/null || exit 0
 

--- a/etc/zfs-auto-snapshot.cron.monthly
+++ b/etc/zfs-auto-snapshot.cron.monthly
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+PATH="$PATH:/usr/local/sbin"
+
 # Only call zfs-auto-snapshot if it's available
 which zfs-auto-snapshot > /dev/null || exit 0
 

--- a/etc/zfs-auto-snapshot.cron.weekly
+++ b/etc/zfs-auto-snapshot.cron.weekly
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+PATH="$PATH:/usr/local/sbin"
+
 # Only call zfs-auto-snapshot if it's available
 which zfs-auto-snapshot > /dev/null || exit 0
 


### PR DESCRIPTION
Cronie - the cron daemon on EL7 - doesn't inherit the `PATH` from `/etc/crontab` when running the scripts in `/etc/cron.[hourly|daily|weekly|monthly]`.  Add `/usr/local/sbin` to `PATH` for these scripts.