### PR TITLE
Set permissions on man page to 0644 when installing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,6 @@ install:
 	install etc/zfs-auto-snapshot.cron.weekly   $(DESTDIR)/etc/cron.weekly/zfs-auto-snapshot
 	install etc/zfs-auto-snapshot.cron.monthly  $(DESTDIR)/etc/cron.monthly/zfs-auto-snapshot
 	install -d $(DESTDIR)$(PREFIX)/share/man/man8
-	install src/zfs-auto-snapshot.8 $(DESTDIR)$(PREFIX)/share/man/man8/zfs-auto-snapshot.8
+	install -m 0644 src/zfs-auto-snapshot.8 $(DESTDIR)$(PREFIX)/share/man/man8/zfs-auto-snapshot.8
 	install -d $(DESTDIR)$(PREFIX)/sbin
 	install src/zfs-auto-snapshot.sh $(DESTDIR)$(PREFIX)/sbin/zfs-auto-snapshot


### PR DESCRIPTION
Man page is being installed with execute permissions.  This patch resolves that issue.