### PR TITLE
Improve performance of listings

### DIFF
--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -367,20 +367,20 @@ fi
 ZPOOL_STATUS=$(env LC_ALL=C zpool status 2>&1 ) \
   || { print_log error "zpool status $?: $ZPOOL_STATUS"; exit 135; }
 
-ZFS_LIST=$(env LC_ALL=C zfs list -H -t filesystem,volume -s name \
-  -o name,com.sun:auto-snapshot,com.sun:auto-snapshot:"$opt_label") \
+ZFS_LIST=$(env LC_ALL=C zfs list -r -H -t filesystem,volume -s name \
+  -o name,com.sun:auto-snapshot,com.sun:auto-snapshot:"$opt_label" "${@}") \
   || { print_log error "zfs list $?: $ZFS_LIST"; exit 136; }
 
 if [ -n "$opt_fast_zfs_list" ]
 then
-	SNAPSHOTS_OLD=$(env LC_ALL=C zfs list -H -t snapshot -o name -s name | \
+	SNAPSHOTS_OLD=$(env LC_ALL=C zfs list -r -H -t snapshot -o name -s name "${@}" | \
 		grep $opt_prefix | \
 		awk '{ print substr( $0, length($0) - 14, length($0) ) " " $0}' | \
 		sort -r -k1,1 -k2,2 | \
 		awk '{ print substr( $0, 17, length($0) )}') \
 	  || { print_log error "zfs list $?: $SNAPSHOTS_OLD"; exit 137; }
 else
-	SNAPSHOTS_OLD=$(env LC_ALL=C zfs list -H -t snapshot -S creation -o name) \
+	SNAPSHOTS_OLD=$(env LC_ALL=C zfs list -r -H -t snapshot -S creation -o name "${@}" ) \
 	  || { print_log error "zfs list $?: $SNAPSHOTS_OLD"; exit 137; }
 fi
 


### PR DESCRIPTION
There are two things that we need to list:
* filesystems and volumes that we may touch
* snapshots that we may need to clean up

In both cases, we were previously listing _all_ of these, across the entire system and all pools.

With these changes, we will only list the relevant entities, reducing time spent processing each event.

This should address #62, and helps with #16.

## Listing Filesystems and Volumes
### Before
```
$ time zfs list -H -t filesystem,volume -s name \
    -o name,com.sun:auto-snapshot,com.sun:auto-snapshot:frequent | wc -l
631

real    0m0.523s
user    0m0.020s
sys     0m0.500s
```

### After
```
$ time zfs list -r -H -t filesystem,volume -s name \
    -o name,com.sun:auto-snapshot,com.sun:auto-snapshot:frequent ell/users | wc -l
84

real    0m0.054s
user    0m0.016s
sys     0m0.032s
```

## Listing Snapshots
### Before
```
$ time zfs list -H -t snapshot -o name -s name | wc -l
41267

real    0m12.273s
user    0m0.124s
sys     0m12.144s
```

### After
```
$ time zfs list -r -H -t snapshot -o name -s name ell/users | wc -l
24304

real    0m0.410s
user    0m0.056s
sys     0m0.352s
```