### PR TITLE
Fix recursive snapshots for datasets with noauto descendants

### DIFF
--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -440,11 +440,16 @@ do
 	# Just testing "$ii" != ${ii#$jj} would incorrectly match.
 	iii="$ii/"
 
-	# Exclude datasets that are not named on the command line.
+	# Exclude datasets
+	# * that are not named on the command line or
+	# * those whose prefix is not on the command line (if --recursive flag is set)
 	IN_ARGS='0'
 	for jj in "$@"
 	do
 		if [ "$jj" = '//' -o "$jj" = "$ii" ]
+		then
+			IN_ARGS=$(( $IN_ARGS + 1 ))
+		elif [ -n "$opt_recursive" -a "$iii" != "${iii#$jj}" ]
 		then
 			IN_ARGS=$(( $IN_ARGS + 1 ))
 		fi


### PR DESCRIPTION
Fixes #80

Caveat: as explained in #80 this comes at the cost of not having one atomic snapshot for all descendant filesystems. But this would be the case anyway when using `//`.