### PR TITLE
Standardized PATH across cronjobs, changed unfound script exit code on error to 1

### DIFF
--- a/etc/zfs-auto-snapshot.cron.daily
+++ b/etc/zfs-auto-snapshot.cron.daily
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+PATH="/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
+
 # Only call zfs-auto-snapshot if it's available
 which zfs-auto-snapshot > /dev/null || exit 0
 

--- a/etc/zfs-auto-snapshot.cron.daily
+++ b/etc/zfs-auto-snapshot.cron.daily
@@ -3,6 +3,6 @@
 PATH="/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
 
 # Only call zfs-auto-snapshot if it's available
-which zfs-auto-snapshot > /dev/null || exit 0
+which zfs-auto-snapshot > /dev/null || exit 1
 
 exec zfs-auto-snapshot --quiet --syslog --label=daily --keep=31 //

--- a/etc/zfs-auto-snapshot.cron.frequent
+++ b/etc/zfs-auto-snapshot.cron.frequent
@@ -2,4 +2,6 @@
 
 PATH="/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
 
-*/15 * * * * root which zfs-auto-snapshot > /dev/null || exit 0 ; zfs-auto-snapshot --quiet --syslog --label=frequent --keep=4 //
+*/15 * * * * root which zfs-auto-snapshot > /dev/null || exit 1
+
+exec zfs-auto-snapshot --quiet --syslog --label=frequent --keep=4 //

--- a/etc/zfs-auto-snapshot.cron.frequent
+++ b/etc/zfs-auto-snapshot.cron.frequent
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 PATH="/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
 
 */15 * * * * root which zfs-auto-snapshot > /dev/null || exit 0 ; zfs-auto-snapshot --quiet --syslog --label=frequent --keep=4 //

--- a/etc/zfs-auto-snapshot.cron.hourly
+++ b/etc/zfs-auto-snapshot.cron.hourly
@@ -1,6 +1,8 @@
 #!/bin/sh
 
+PATH="/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
+
 # Only call zfs-auto-snapshot if it's available
-which zfs-auto-snapshot > /dev/null || exit 0
+which zfs-auto-snapshot > /dev/null || exit 1
 
 exec zfs-auto-snapshot --quiet --syslog --label=hourly --keep=24 //

--- a/etc/zfs-auto-snapshot.cron.monthly
+++ b/etc/zfs-auto-snapshot.cron.monthly
@@ -1,6 +1,8 @@
 #!/bin/sh
 
+PATH="/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
+
 # Only call zfs-auto-snapshot if it's available
-which zfs-auto-snapshot > /dev/null || exit 0
+which zfs-auto-snapshot > /dev/null || exit 1
 
 exec zfs-auto-snapshot --quiet --syslog --label=monthly --keep=12 //

--- a/etc/zfs-auto-snapshot.cron.weekly
+++ b/etc/zfs-auto-snapshot.cron.weekly
@@ -1,6 +1,8 @@
 #!/bin/sh
 
+PATH="/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
+
 # Only call zfs-auto-snapshot if it's available
-which zfs-auto-snapshot > /dev/null || exit 0
+which zfs-auto-snapshot > /dev/null || exit 1
 
 exec zfs-auto-snapshot --quiet --syslog --label=weekly --keep=8 //


### PR DESCRIPTION
Two changes:

Added PATH variable as script isn't found in CentOS 7

Changed exit error code to 1 -- not sure why we would not want to error if we can't find the script.