### PR TITLE
Support macOS with Homebrew gnu-getopt

### DIFF
--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -207,7 +207,13 @@ do_snapshots () # properties, flags, snapname, oldglob, [targets...]
 # main ()
 # {
 
-GETOPT=$(getopt \
+if [ "$(uname)" == "Darwin" ]; then
+  GETOPT_BIN="$(brew --prefix gnu-getopt 2> /dev/null || echo /usr/local)/bin/getopt"
+else
+  GETOPT_BIN="getopt"
+fi
+
+GETOPT=$($GETOPT_BIN \
   --longoptions=default-exclude,dry-run,fast,skip-scrub,recursive \
   --longoptions=event:,keep:,label:,prefix:,sep: \
   --longoptions=debug,help,quiet,syslog,verbose \
@@ -536,7 +542,7 @@ SNAPPROP="-o com.sun:auto-snapshot-desc='$opt_event'"
 
 # ISO style date; fifteen characters: YYYY-MM-DD-HHMM
 # On Solaris %H%M expands to 12h34.
-DATE=$(date --utc +%F-%H%M)
+DATE=$(date -u +%F-%H%M)
 
 # The snapshot name after the @ symbol.
 SNAPNAME="$opt_prefix${opt_label:+$opt_sep$opt_label}-$DATE"


### PR DESCRIPTION
I am running macOS 10.13.6 High Sierra and use ZFS for my external disk. I already use this script on Ubuntu to create snapshots, and I would like to be able to run it on macOS as well. I encountered two problems: macOS/BSD `getopt` does not support long options, so the script could try to use the GNU getopt from [Homebrew](brew.sh), if it is found. Homebrew does not install GNU getopt to /usr/local for compatibility reasons, so the script must specify the entire path. Also `date` does not support the `--utc` option on macOS, only `-u`, which has the same effect. With those changes, this script runs fine on macOS.