### PR TITLE
fix for verbose logging not working

### DIFF
--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -110,7 +110,7 @@ print_log () # level, message, ...
 			;;
 		(inf*)
 			# test -n "$opt_syslog" && logger -t "$opt_prefix" -p daemon.info $*
-			test -z ${opt_quiet+x} && test -n "$opt_verbose" && echo $*
+			test -z "$opt_quiet" && test -n "$opt_verbose" && echo $*
 			;;
 		(deb*)
 			# test -n "$opt_syslog" && logger -t "$opt_prefix" -p daemon.debug $*


### PR DESCRIPTION
fix https://github.com/zfsonlinux/zfs-auto-snapshot/issues/97

Fixes errant behavior that `--verbose` logging doesn't log info class log events.
Repo cases in above issue