### PR TITLE
--localtime: Use local time instead of UTC (include timezone abbrevation in the name)

### DIFF
--- a/src/zfs-auto-snapshot.8
+++ b/src/zfs-auto-snapshot.8
@@ -85,6 +85,10 @@ snapshot all datasets, then run post-snapshot
 command(s) and clean up with zfs-auto-snapshot
 \fB\-\-destroy-only\fR.
 .TP
+\fB\-L\fR, \fB\-\-localtime\fR
+Use local time instead of UTC for snapshot names. In this case
+the timezone abbreviation is added to the name.
+.TP
 name
 Filesystem and volume names, or '//' for all ZFS datasets.
 .SH SEE ALSO

--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -208,19 +208,20 @@ do_snapshots () # properties, flags, snapname, oldglob, [targets...]
 		do
 			# Check whether this is an old snapshot of the filesystem.
 			trunc="$ii@$NAMETRUNC"
-			if [ "${jj:0:${#trunc}}" = "$trunc" ]
-			then
-				KEEP=$(( $KEEP - 1 ))
-				if [ "$KEEP" -le '0' ]
-				then
-					if do_run "zfs destroy -d $FLAGS '$jj'" 
+			case "${jj}" in
+				(${trunc}*)
+					KEEP=$(( $KEEP - 1 ))
+					if [ "$KEEP" -le '0' ]
 					then
-						DESTRUCTION_COUNT=$(( $DESTRUCTION_COUNT + 1 ))
-					else
-						WARNING_COUNT=$(( $WARNING_COUNT + 1 ))
+						if do_run "zfs destroy -d $FLAGS '$jj'" 
+						then
+							DESTRUCTION_COUNT=$(( $DESTRUCTION_COUNT + 1 ))
+						else
+							WARNING_COUNT=$(( $WARNING_COUNT + 1 ))
+						fi
 					fi
-				fi
-			fi
+					;;
+			esac
 		done
 	done
 }


### PR DESCRIPTION
Yet another proposed solution for the date problem (#74), which also address the possible name collision because of DST.

The default behaviour is unchanged but a new option is added: -L or --localtime.
Ẃith this option, the local time is used and the timezone abbreviation is added to the name.
This avoid problems with DST and also avoid confusion when switching from UTC to local time.
The matching mechanism in do_snapshot to identify older snapshots was modified so as to match both formats (UTC without timezone indication and localtime with timezone) and also accept variable-length strings since the timezone abbreviation has variable length.