### PR TITLE
Override path like in zfs-auto-snapshot.cron.frequent

### DIFF
--- a/etc/zfs-auto-snapshot.cron.daily
+++ b/etc/zfs-auto-snapshot.cron.daily
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+PATH="/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
+
 # Only call zfs-auto-snapshot if it's available
 which zfs-auto-snapshot > /dev/null || exit 0
 

--- a/etc/zfs-auto-snapshot.cron.hourly
+++ b/etc/zfs-auto-snapshot.cron.hourly
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+PATH="/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
+
 # Only call zfs-auto-snapshot if it's available
 which zfs-auto-snapshot > /dev/null || exit 0
 

--- a/etc/zfs-auto-snapshot.cron.monthly
+++ b/etc/zfs-auto-snapshot.cron.monthly
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+PATH="/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
+
 # Only call zfs-auto-snapshot if it's available
 which zfs-auto-snapshot > /dev/null || exit 0
 

--- a/etc/zfs-auto-snapshot.cron.weekly
+++ b/etc/zfs-auto-snapshot.cron.weekly
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+PATH="/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
+
 # Only call zfs-auto-snapshot if it's available
 which zfs-auto-snapshot > /dev/null || exit 0
 


### PR DESCRIPTION
Using the installation method described in README on a fresh CentOS 8 install will result in the {hourly,daily,weekly,monthly} snapshots not being created while the 'frequent' ones are.

In the system log, one can read:
```
Dec 29 13:01:01 obfuscated CROND[6339]: (root) CMDOUT (/etc/cron.hourly/zfs-auto-snapshot:)
Dec 29 13:01:01 obfuscated CROND[6339]: (root) CMDOUT ()
Dec 29 13:01:01 obfuscated CROND[6339]: (root) CMDOUT (which: no zfs-auto-snapshot in (/sbin:/bin:/usr/sbin:/usr/bin))
```

By default, the script is installed under `/usr/local/bin`, which is not in the PATH when cron runs.
This PR add a PATH declaration to the {hourly,daily,weekly,monthly} cron files, similar to the frequent one.