### PR TITLE
Accept on and off as well as true and false in zfs command outputs

### DIFF
--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -453,7 +453,7 @@ ZPOOLS_NOTREADY=$(echo "$ZPOOL_STATUS" | awk -F ': ' \
 
 # Get a list of datasets for which snapshots are explicitly disabled.
 NOAUTO=$(echo "$ZFS_LIST" | awk -F '\t' \
-  'tolower($2) ~ /false/ || tolower($3) ~ /false/ {print $1}')
+  'tolower($2) ~ /false|off/ || tolower($3) ~ /false|off/ {print $1}')
 
 # If the --default-exclude flag is set, then exclude all datasets that lack
 # an explicit com.sun:auto-snapshot* property. Otherwise, include them.
@@ -461,11 +461,11 @@ if [ -n "$opt_default_exclude" ]
 then
 	# Get a list of datasets for which snapshots are explicitly enabled.
 	CANDIDATES=$(echo "$ZFS_LIST" | awk -F '\t' \
-	  'tolower($2) ~ /true/ || tolower($3) ~ /true/ {print $1}')
+	  'tolower($2) ~ /true|on/ || tolower($3) ~ /true|on/ {print $1}')
 else
 	# Invert the NOAUTO list.
 	CANDIDATES=$(echo "$ZFS_LIST" | awk -F '\t' \
-	  'tolower($2) !~ /false/ && tolower($3) !~ /false/ {print $1}')
+	  'tolower($2) !~ /false|off/ && tolower($3) !~ /false|off/ {print $1}')
 fi
 
 # Initialize the list of datasets that will get a recursive snapshot.


### PR DESCRIPTION
Today i noticed that zfs-auto-snapshot has not been snapshoting my filesystems for three months now.

After some digging I found out that the zfs command outputs "on" and "off" as values of boolean properties, but zfs-auto-snapshot only accepts "true" and "false".

This pull request modifies the script to accept both formats.

I didn't check why or when the output format was changed ...