### PR TITLE
Fix Solaris mismatch where snapshot labels cannot be enabled when snapshots are disabled globally

### DIFF
--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -463,9 +463,11 @@ then
 	CANDIDATES=$(echo "$ZFS_LIST" | awk -F '\t' \
 	  'tolower($2) ~ /true/ || tolower($3) ~ /true/ {print $1}')
 else
-	# Invert the NOAUTO list.
+	# Get a list of datasets for which snapshots are either not explicitly
+ 	# disabled, or explicitly enabled for the specific label.
 	CANDIDATES=$(echo "$ZFS_LIST" | awk -F '\t' \
-	  'tolower($2) !~ /false/ && tolower($3) !~ /false/ {print $1}')
+	  '(tolower($2) !~ /false/ && tolower($3) !~ /false/) \
+	  || tolower($3) ~ /true/ {print $1}')
 fi
 
 # Initialize the list of datasets that will get a recursive snapshot.


### PR DESCRIPTION
To match the Solaris implementation, it should be possible to disable all snapshots via the `com.sun:auto-snapshot` property, and subsequently override that parameter by explicitly enabling individual labels.

This is achieved when opt_default_exclude is disabled (the default behavior) by adding datasets for which the label is explicitly enabled (`com.sun:auto-snapshot:<label>=true`) to CANDIDATES regardless of the value of `com.sun:auto-snapshot`.

That will allow users to ignore all automatic snapshots except for weekly ones via `zfs set com.sun:auto-snapshot=false dataset; zfs set com.sun:auto-snapshot:weekly=true dataset`, as documented [here](https://docs.oracle.com/cd/E19120-01/open.solaris/817-2271/gbcxl/index.html). Right now `weekly` will still be skipped in this scenario.

I tested the awk selector to make sure the correct datasets would be returned on my system, but I have a simple hierarchy and configuration, so I may not be aware of implications of this change on more complex hierarchies.

Fixes #127.