### PR TITLE
Use local time instead of utc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+zfs-auto-snapshot.code-workspace

--- a/src/zfs-auto-snapshot.8
+++ b/src/zfs-auto-snapshot.8
@@ -40,6 +40,9 @@ Keep NUM recent snapshots and destroy older snapshots.
 \fB\-l\fR, \fB\-\-label\fR=\fILAB\fR
 LAB is usually 'hourly', 'daily', or 'monthly'.
 .TP
+\fB\-L\fR, \fB\-\-local\-time\fR
+Use local time instead of UTC for snapshots.
+.TP
 \fB\-p\fR, \fB\-\-prefix\fR=\fIPRE\fR
 PRE is 'zfs\-auto\-snap' by default.
 .TP

--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -43,6 +43,7 @@ opt_pre_snapshot=''
 opt_post_snapshot=''
 opt_do_snapshots=1
 opt_min_size=0
+opt_local=0
 
 # Global summary statistics.
 DESTRUCTION_COUNT='0'
@@ -65,6 +66,7 @@ print_usage ()
   -h, --help         Print this usage message.
   -k, --keep=NUM     Keep NUM recent snapshots and destroy older snapshots.
   -l, --label=LAB    LAB is usually 'hourly', 'daily', or 'monthly'.
+  -L, --local-time   Use local time for snapshot names instead of UTC.
   -p, --prefix=PRE   PRE is 'zfs-auto-snap' by default.
   -q, --quiet        Suppress warnings and notices at the console.
       --send-full=F  Send zfs full backup. Unimplemented.
@@ -294,6 +296,10 @@ do
 		(-l|--label)
 			opt_label="$2"
 			shift 2
+			;;
+		(-L|--local-time)
+			opt_local=1
+			shift 1
 			;;
 		(-m|--min-size)
 			opt_min_size="$2"
@@ -585,7 +591,12 @@ SNAPPROP="-o com.sun:auto-snapshot-desc='$opt_event'"
 # ISO style date; fifteen characters: YYYY-MM-DD-HHMM
 # On Solaris %H%M expands to 12h34.
 # We use the shortfirm -u here because --utc is not supported on macos.
-DATE=$(date -u +%F-%H%M)
+if [ $opt_local	-eq 1]
+then
+	DATE=$(date +%F-%H%M)
+else
+	DATE=$(date -u +%F-%H%M)
+fi
 
 # The snapshot name after the @ symbol.
 SNAPNAME="${opt_prefix:+$opt_prefix$opt_sep}${opt_label:+$opt_label}-$DATE"

--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -233,12 +233,12 @@ else
 fi
 
 GETOPT=$($GETOPT_BIN \
-  --longoptions=default-exclude,dry-run,fast,skip-scrub,recursive \
+  --longoptions=default-exclude,dry-run,fast,local-time,skip-scrub,recursive \
   --longoptions=event:,keep:,label:,prefix:,sep: \
   --longoptions=debug,help,quiet,syslog,verbose \
   --longoptions=pre-snapshot:,post-snapshot:,destroy-only \
   --longoptions=min-size: \
-  --options=dnshe:l:k:p:rs:qgvm: \
+  --options=dnshe:l:Lk:p:rs:qgvm: \
   -- "$@" ) \
   || exit 128
 
@@ -591,7 +591,7 @@ SNAPPROP="-o com.sun:auto-snapshot-desc='$opt_event'"
 # ISO style date; fifteen characters: YYYY-MM-DD-HHMM
 # On Solaris %H%M expands to 12h34.
 # We use the shortfirm -u here because --utc is not supported on macos.
-if [ $opt_local	-eq 1]
+if [ $opt_local	-eq 1 ]
 then
 	DATE=$(date +%F-%H%M)
 else


### PR DESCRIPTION
The utility uses UTC by default to name the snapshots, but this can be confusing with a system running on local time.

Added options -L and --local-time to preserve default operation, but allow using local time for the snapshot names instead.